### PR TITLE
chore: move api to api.thegoat.ir

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-  "API_HOST_NAME": "api.mahdyar.me",
+  "API_HOST_NAME": "api.thegoat.ir",
   "API_PORT_NUMBER": 443,
   "API_TOKEN": "thegoat-cli"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thegoat",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "The Goat",
   "main": "cli.js",
   "scripts": {


### PR DESCRIPTION
Closes #2 

Note: `api.mahdyar.me` will still be responding to the whois lookup requests until `1/5/2021`.